### PR TITLE
Add build tools so package does not fall back to pure Python

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,4 +6,4 @@ set -e
 # apk add --no-cache gcc musl-dev
 
 # build
-pip wheel --no-deps --requirement requirements.txt
+pip wheel -vvv --no-deps --requirement requirements.txt

--- a/build.sh
+++ b/build.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-# install os dependencies
-# apk add --no-cache gcc musl-dev
+# install dependencies
+apk add --no-cache gcc musl-dev
 
 # build
 pip wheel -vvv --no-deps --requirement requirements.txt

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 set -e
 
 # install dependencies
-apk add --no-cache gcc musl-dev
+apk add --no-cache g++ gcc musl-dev
 
 # build
 pip wheel -vvv --no-deps --requirement requirements.txt

--- a/build.sh
+++ b/build.sh
@@ -6,4 +6,4 @@ set -e
 apk add --no-cache g++ gcc musl-dev
 
 # build
-pip wheel -vvv --no-deps --requirement requirements.txt
+pip wheel --no-deps --requirement requirements.txt


### PR DESCRIPTION
Make `pip` output verbose to see if there is an attempt to build the package.